### PR TITLE
Changed tokenBalance module to "account"

### DIFF
--- a/src/Etherscan.php
+++ b/src/Etherscan.php
@@ -335,7 +335,7 @@ class Etherscan {
      */
     public function tokenBalance($tokenIdentifier, $address, $tag = EtherscanAPIConf::TAG_LATEST) {
         $params = [
-            'module' => "stats",
+            'module' => "account",
             'action' => "tokenbalance",
             'address' => $address,
             'tag' => $tag


### PR DESCRIPTION
The module parameter for the tokenBalance call should be "account"  (with a module "stats" the call returns an error).
See https://etherscan.io/apis#tokens