### PR TITLE
Added full url alternative to getAPIUrl()

### DIFF
--- a/src/EtherscanAPIConf.php
+++ b/src/EtherscanAPIConf.php
@@ -23,15 +23,23 @@ class EtherscanAPIConf {
     /**
      * Returns API basic URL.
      *
-     * @param string $net Mainnet - if null, or testnet if provided.
+     * @param string $net if null then return Mainnet. Otherwise return url / testnet if provided.
      *
      * @return string
      */
     public static function getAPIUrl($net = null) {
+        
+        // If $net is null return default mainnet url
         if (is_null($net)) {
             return self::API_URL;
         }
-
+        
+        // If $net is valid URL then return
+        if (filter_var($net, FILTER_VALIDATE_URL)) {
+            return $net;
+        }
+        
+        // Otherwise treat $net as testnet name
         return "https://{$net}.etherscan.io/api";
     }
 


### PR DESCRIPTION
Added additional if statement to check if $net contains valid URL if so then function returns $net. This allows the ability to point etherscan API mirrors / clones in the event that etherscan site isn't accessible.