### PR TITLE
Add missing article "a" in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The minimum requirement by EtherScan API is that your Web server supports PHP 5.
 
 Installation
 ------------
-To install EtherScan API package you can use simple `composer.json`...
+To install EtherScan API package you can use a simple `composer.json`...
 
 ```javascript
 {


### PR DESCRIPTION
Added the missing article "a" in the installation instructions section of the README file to improve clarity. The sentence "To install EtherScan API package you can use simple composer.json..." was corrected to "To install the EtherScan API package you can use a simple composer.json...".